### PR TITLE
Removes unnecessary blank line in the Security section

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,10 +201,9 @@ http://windows.microsoft.com/en-IN/windows-8/clean-install
 - [SpyBot](https://www.safer-networking.org/) - Search and destroy malware, spyware and viruses.
 - [UnChecky](https://unchecky.com/) - automatically unchecks unrelated offers from installers.
 - [Malwarebytes](https://www.malwarebytes.org/) - protects from dangerous threats that antivirus doesn't.
-
-* [Tor Project](https://www.torproject.org/) - Enable anonymous communication. [![Open-Source Software][OSS Icon]](https://github.com/TheTorProject)
-* [Windows 10 Paranoid's Guide](http://www.zdnet.com/article/how-to-secure-windows-10-the-paranoids-guide/)
-* [Disable Data Logging](https://www.reddit.com/r/Windows10/comments/3f38ed/guide_how_to_disable_data_logging_in_w10) - Make Windows 10 more private and safe.
+- [Tor Project](https://www.torproject.org/) - Enable anonymous communication. [![Open-Source Software][OSS Icon]](https://github.com/TheTorProject)
+- [Windows 10 Paranoid's Guide](http://www.zdnet.com/article/how-to-secure-windows-10-the-paranoids-guide/)
+- [Disable Data Logging](https://www.reddit.com/r/Windows10/comments/3f38ed/guide_how_to_disable_data_logging_in_w10) - Make Windows 10 more private and safe.
 - [Viscosity](https://www.sparklabs.com/viscosity/) - Fully-featured OpenVPN client, ready for enterprise deployment.
 
 


### PR DESCRIPTION
Seems like GitHub has formatting issues when you include both `-` characters and `*` characters in the same bulleted list, so I replaced all of the `*` in that section to `-` and removed the blank line to remove the formatting issue.

Screenshot of the formatting issue:

![screenshot from 2016-06-08 01-33-47](https://cloud.githubusercontent.com/assets/4890548/15878165/1f1c0abe-2d19-11e6-81d0-cf46ddd7da3a.png)
