### PR TITLE
Add PowerPlanSwitcher

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,6 +249,7 @@
 - [HTTrack](https://www.httrack.com/page/2/en/index.html)- Offline browser utility, allowing you to download a website from the Internet to a local directory. [![Open-Source Software][OSS Icon]](https://github.com/xroche/httrack/tree/master)
 - [LICEcap](http://www.cockos.com/licecap/) - Animated screen captures and save them directly to .GIF
 - [rimraf](https://www.npmjs.com/package/rimraf) - A deep deletion module for node. Help to delete files and folders with very long paths
+- [PowerPlanSwitcher](https://www.microsoft.com/en-us/store/p/powerplanswitcher/9nblggh556l3) - Provides a quick UI for switching power schemas & automatic switch on AC-plug-in on Windows10. [![Open-Source Software][OSS Icon]](https://github.com/petrroll/PowerSwitcher)
 - [SDelete](https://technet.microsoft.com/en-us/sysinternals/sdelete.aspx) -  A command line utility that can securely delete a file, or clean the slack space.
 - [SpaceMonger](https://spacemonger.en.softonic.com/download) - A graphical utility to display folders and files in blocks relative to their disk usage.
 - [Speccy](https://www.piriform.com/speccy) -Detailed statistics on every piece of hardware in your computer.


### PR DESCRIPTION
About:
PowerPlanSwitcher is a simple app that allows you to quickly switch between power plan schemas from application tray. In addition to a manual schemas switching it also supports an automatic switch when AC adapter gets connected/disconnected.
Features:
- Windows10 styled flyout that allows quick power plan schemas changing
- Ability to limit flyout only to Windows default power plan schemas
- Automatic schema switching when AC adapter gets connected / disconnected
- Launch on Windows startup
- Flyout shortcut (Shift+Win+L)
- Navigate the flyout with keyboard (use tab)
- Change all settings by right-clicking on the tray icon :)