### PR TITLE
Add Easy Window Switcher to Productivity section

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,6 +218,7 @@
 - [Cold Turkey](https://getcoldturkey.com) - The only blocker for distracting websites that actually works. (even doesn't let you uninstall it when blocking is active).
 - [Chocolatey](https://chocolatey.org/) - A package manager for Windows.
 - [Ditto](http://ditto-cp.sourceforge.net/) - Clipboard manager.
+- [Easy Window Switcher](https://neosmart.net/EasySwitch/) - Switch between application instances, fast.
 - [Everything](http://www.voidtools.com/) - The fastest file/folder search tool by name.
 - [f.lux](http://stereopsis.com/flux/) - Automatically adjust your computer screen to match lighting. ![Freeware][Freeware Icon]
 - [Inkdrop](https://www.inkdrop.info/) - The note-taking app for Markdown lovers.


### PR DESCRIPTION
This tool makes it possible to switch between application instances only. You don't have to cycle through the default app switcher or task view on Windows 10. Just hit ``ALT + ` `` (backtick) and switch between instances of an IDE for example. 

Incredible time saver if you have open two solutions in an IDE but have to switch constantly between them.