### PR TITLE
Mark Insomnia as Free and Open Source

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@
 - [GitHub Desktop](https://windows.github.com/) - A GUI for using GitHub.
 - [GitKraken](https://www.gitkraken.com/) - A beautiful, cross-platform Git client. ![Freeware][Freeware Icon]
 - [I'm Only Resting](http://www.swensensoftware.com/im-only-resting) -A feature-rich WinForms-based HTTP client [![Open-Source Software][OSS Icon]](https://github.com/swensensoftware/im-only-resting) ![Freeware][Freeware Icon]
-- [Insomnia](http://insomnia.rest) - A modern REST client with a beautiful interface.
+- [Insomnia](http://insomnia.rest) - A modern REST client with a beautiful interface. ![Open-Source Software][OSS Icon] ![Freeware][Freeware Icon]
 - [Keylord](https://protonail.com/products/keylord) Cross-platform GUI client for Redis, LevelDB and Memcached key-value databases.
 - [Open Server](https://ospanel.io/) - Portable server platform and software environment (like MAMP, XAMP, WAMP and very user friendly). ![Freeware][Freeware Icon]
 - [Pixie](http://www.nattyware.com/pixie.php) - A simple color picker for developers.


### PR DESCRIPTION
First of all, thanks for including Insomnia in this list! 

I've gone ahead and added the free and open source icons for [Insomnia](https://insomnia.rest). Insomnia _does_ have a paid add-on for data synchronization but the desktop application itself is free and open source. If you do not wish to add the free icon for "freemium" apps, I can change it to just include the open source icon.

Let me know what you think.

http://github.com/getinsomnia/insomnia