### PR TITLE
Add Mailspring (email client)

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,7 +163,8 @@
 
 - [MailBird](https://www.mailbird.com/) - IMAP and POP3 email client, featuring customization, complete touch support and multiple language support.
 - [Thunderbird](https://www.mozilla.org/en-US/thunderbird/) - Email client with minimalistic design. ![Freeware][Freeware Icon]
-- [Nylas N1](https://www.nylas.com/download/) - An extensible desktop mail app built on the modern web. [![Open-Source Software][OSS Icon]](https://github.com/nylas/N1) ![Freeware][Freeware Icon]
+- [Mailspring](https://getmailspring.com/) - A fast and maintained fork of Nylas Mail, built on modern web technologies. [![Open-Source Software][OSS Icon]](https://github.com/Foundry376/Mailspring) ![Freeware][Freeware Icon]
+- [Nylas Mail](https://www.nylas.com/download/) - An extensible desktop mail app built on the modern web. [![Open-Source Software][OSS Icon]](https://github.com/nylas/N1) ![Freeware][Freeware Icon]
 - [Postbox](https://postbox-inc.com/) - The Power Email App
 
 ### Games


### PR DESCRIPTION
- Renamed Nylas N1 email client to Nylas Mail (see here for more info regarding name change: https://www.nylas.com/blog/nylas-mail-is-now-free)
- Added Mailspring email client, a continuation fork of Nylas Mail with a faster and improved C++ mail sync engine (https://github.com/Foundry376/Mailspring).