### PR TITLE
Add AudioNodes to Audio

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@
 
 - [AIMP](http://www.aimp.ru/) - 32 bit audio processing and multi-format playback. ![Freeware][Freeware Icon]
 - [Audacity](http://audacityteam.org/) - Free, open source, cross-platform software for recording and editing sounds. [![Open-Source Software][OSS Icon]](https://github.com/audacity/audacity) ![Freeware][Freeware Icon]
+- [AudioNodes](https://audionodes.com/) - Modular audio production suite with multi-track audio mixing, audio effects, parameter automation, MIDI editing, synthesis, cloud production, and more. ![Freeware][Freeware Icon]
 - [CDex](http://www.cdex.fr/) - CD Ripper (French site, English program). ![Freeware][Freeware Icon]
 - [Dopamine](http://www.digimezzo.com/software/dopamine/) - An audio player which tries to make organizing and listening to music as simple and pretty as possible. ![Freeware][Freeware Icon]
 - [K-Lite Codecs](http://www.codecguide.com/download_kl.htm) - Collection of DirectShow filters, VFW/ACM codecs, and tools. ![Freeware][Freeware Icon]


### PR DESCRIPTION
Hello,

I'd like to include [AudioNodes](https://audionodes.com) on this list. It's a free, modular audio production tool which I believe has a remarkable set of features for a free application, as well as a near-identical online version.

Features include audio mixing, audio effects composing, MIDI editing and generating, controller keyboard support, cloud production options, and audio visualization.

 - [Online demo](https://audionodes.com/online)
 - [Download (64-bit unsigned)](https://audionodes.com/download)

-----

![2017-12-06 12](https://user-images.githubusercontent.com/13468659/36370850-7019f580-1560-11e8-9b0d-be74197bf4cc.png)

**AudioNodes can be used primarily for:**

 - Audio mixing, there is an unlimited number of audio and envelope tracks, and clips can be freely moved between tracks
 - MIDI editing and MIDI-driven modular synthesis, AudioNodes has a lightweight piano roll in it, you might know this primarily from paid professional software
 - Effects processing and engineering, AudioNodes is modular and you can wire up effects in virtually unlimited combinations

There's also going to be an update likely this week or the next, which will introduce experimental plugin support, as this is something people have been requesting for some time now. Also some fixes and other improvements.

**Technical specs**

 - 32 bit floating-point audio processing
 - 64 bit floating-point timing
 - VST 2.4 support (coming soon)
 - Unlimited tracks and mixer channels, up to 32 audio channels
 - Modular architecture

-----

I hope this is a valuable and appropriate addition to this list, thank you for your time.

*Commit notes: I inserted AudioNodes at its alphabetical place. The download is available behind a 100% optional pay-what-you-want gate, and the online version is also completely free. I hope this qualifies as freeware. If not, please let me know, we can strip the icon.*