### PR TITLE
Thunderbird open source icon and link added

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@
 ### Email
 
 - [MailBird](https://www.mailbird.com/) - IMAP and POP3 email client, featuring customization, complete touch support and multiple language support.
-- [Thunderbird](https://www.mozilla.org/en-US/thunderbird/) - Email client with minimalistic design. ![Freeware][Freeware Icon]
+- [Thunderbird](https://www.mozilla.org/en-US/thunderbird/) - Email client with minimalistic design. [![Open-Source Software][OSS Icon]](https://developer.mozilla.org/en-US/docs/Mozilla/Developer_guide/Build_Instructions/Simple_Thunderbird_build) ![Freeware][Freeware Icon]
 - [Mailspring](https://getmailspring.com/) - A fast and maintained fork of Nylas Mail, built on modern web technologies. [![Open-Source Software][OSS Icon]](https://github.com/Foundry376/Mailspring) ![Freeware][Freeware Icon]
 - [Nylas Mail](https://www.nylas.com/download/) - An extensible desktop mail app built on the modern web. [![Open-Source Software][OSS Icon]](https://github.com/nylas/N1) ![Freeware][Freeware Icon]
 - [Postbox](https://postbox-inc.com/) - The Power Email App


### PR DESCRIPTION
Thunderbird is FOSS, so I added the icon and the link to the build instructions page that have information about the source and the links to the hg repository.