### PR TITLE
Add ClickMonitorDDC

### DIFF
--- a/README.md
+++ b/README.md
@@ -285,6 +285,7 @@
 - [A-Z of Windows Terminal Commands](http://ss64.com/nt/)
 - [Carnac](http://code52.org/carnac/) - The easiest way to record keystrokes during any screen recording.
 - [CleanMyPC](http://macpaw.com/cleanmypc) - A clean computer in no time.
+- [ClickMonitorDDC](http://clickmonitorddc.bplaced.net/) - Change any screen's brightness (or contrast or volume) with only the mousewheel. ![Freeware][Freeware Icon]
 - [CPU-Z](http://www.cpuid.com/softwares/cpu-z.html) - A free all-in-one CPU monitoring tool. ![Freeware][Freeware Icon]
 - [Ext2Fsd](http://www.ext2fsd.com/) - Open source ext3/4 file system driver for Windows.[![Open-Source Software][OSS Icon]](https://github.com/matt-wu/Ext3Fsd) ![Freeware][Freeware Icon]
 - [Far](http://www.farmanager.com/index.php?l=en) - File and Archive manager. Clone of the Norton Commander. [![Open-Source Software][OSS Icon]](http://sourceforge.net/projects/farmanager/)


### PR DESCRIPTION
Adds icons for your monitors in the systray to control the screen's brightness. No more fiddling with annoying on screen menus. I turn of the volume and contrast notification icons. It's also able to deal with multiple monitors, connecting/disconnecting monitors etc. Works with all monitors that I've tried so far, whether over DisplayPort, VGA or DVI. 