### PR TITLE
add Bandicam in Utilities

### DIFF
--- a/README-cn.md
+++ b/README-cn.md
@@ -260,6 +260,7 @@
 
 ### 实用程序
 - [AddToSendTo](https://aashutoshrathi.github.io/Python-Scripts-and-Games/AddToSendTo/) - 通过此脚本，您可以在右键单击时将喜欢的“文件夹”添加到“发送到”选项。 [![Open-Source Software][OSS Icon]](https://aashutoshrathi.github.io/Python-Scripts-and-Games/AddToSendTo/)
+- [Bandicam](https://www.bandicam.com) - 录制软件可以同时轻松录制桌面和3D应用程序。
 - [Carnac](http://code52.org/carnac/) - 在任何屏幕录制期间录制按键的最简单方法。
 - [CleanMyPC](http://macpaw.com/cleanmypc) - 快速的电脑清洁软件。
 - [CPU-Z](http://www.cpuid.com/softwares/cpu-z.html) - 免费且功能齐全的 CPU 监控工具。 ![Freeware][Freeware Icon]

--- a/README.md
+++ b/README.md
@@ -299,6 +299,7 @@
 - [Acrosync](https://acrosync.com/windows.html) - The only native rsync client for Windows (no cygwin required).  It supports automatic uploads on file changes and incremental hourly backups.
 - [AddToSendTo](https://aashutoshrathi.github.io/Python-Scripts-and-Games/AddToSendTo/) - This script lets you add your favorite Folder to Send To option, when you right-click. [![Open-Source Software][OSS Icon]](https://aashutoshrathi.github.io/Python-Scripts-and-Games/AddToSendTo/)
 - [Advanced Renamer](https://www.advancedrenamer.com/) - Advanced batch renaming program, with support for renaming based on GPS data from images, ID3 tags from music files, TV show data and regular expressions. ![Freeware][Freeware Icon]
+- [Bandicam](https://www.bandicam.com) - Recording software allowing easy video recording of both desktop and 3D apps simultaneously.
 - [Carnac](http://code52.org/carnac/) - The easiest way to record keystrokes during any screen recording.
 - [CleanMyPC](http://macpaw.com/cleanmypc) - A clean computer in no time.
 - [CPU-Z](http://www.cpuid.com/softwares/cpu-z.html) - A free all-in-one CPU monitoring tool. ![Freeware][Freeware Icon]


### PR DESCRIPTION
Only recording software currently allowing to record both desktop and 3D apps simultaneously.

Indeed, for users with a discrete graphic card, 3D apps will run on the discrete card while the rest will run on the internal GPU, and all other softwares will only record one or the other, but Bandicam can record both at the same time and with remarkable performance (60 FPS).