### PR TITLE
Add bottom (btm)

### DIFF
--- a/README.md
+++ b/README.md
@@ -292,6 +292,7 @@
 
 - [Alacritty](https://github.com/jwilm/alacritty) - A cross-platform, GPU-accelerated terminal emulator [![Open-Source Software][oss icon]](https://github.com/jwilm/alacritty) ![Freeware][freeware icon]
 - [Babun](http://babun.github.io) - Alternative Windows shell based on Cygwin. [![Open-Source Software][oss icon]](https://github.com/babun/babun) ![Freeware][freeware icon]
+- [bottom](https://github.com/ClementTsang/bottom) - System Resource and Activity Monitor. [![Open-Source Software][oss icon]](https://github.com/ClementTsang/bottom) ![Freeware][freeware icon]
 - [Cmder](https://cmder.net) - Console emulator package with clink shell. [![Open-Source Software][oss icon]](https://github.com/cmderdev/cmder) ![Freeware][freeware icon]
 - [ColorTool](https://github.com/Microsoft/Console/tree/master/tools/ColorTool) - Set custom color schemes for the Windows Console with support for iTerm color schemes.
 - [ConEmu](https://github.com/Maximus5/ConEmu) - Customizable terminal with tabs, splits, quake-style and more.


### PR DESCRIPTION
bottom (https://github.com/ClementTsang/bottom) accurately describes itself as "Yet another cross-platform graphical process/system monitor."

However, unlike the other popular choices (such as ytop, gtop, gotop, vtop, htop, top) which either don't support Windows at all, only support it partially or have horrible performance on Windows - this one works really nicely!