### PR TITLE
Update 7+ Taskbar Tweaker Link

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@
 
 ### Customization
 
-- [7+ Taskbar Tweaker](http://rammichael.com/7-taskbar-tweaker) - Allows to customize and extend Windows taskbar functionality with various productivity enhancements. ![Freeware][freeware icon]
+- [7+ Taskbar Tweaker](https://tweaker.rammichael.com/) - Allows to customize and extend Windows taskbar functionality with various productivity enhancements. ![Freeware][freeware icon]
 - [Classic Start](https://github.com/passionate-coder/Classic-Start) - Use Start Menu and Explorer like it's 2000. [![Open-Source Software][oss icon]](https://github.com/passionate-coder/Classic-Start) ![Freeware][freeware icon]
 - [Clover](http://en.ejie.me/) - Add multi-tab functionality to Windows Explorer. ![Freeware][freeware icon]
 - [EarTrumpet](https://github.com/File-New-Project/EarTrumpet) - Per application volume control from the system tray. [![Open-Source Software][oss icon]](https://github.com/File-New-Project/EarTrumpet) ![Freeware][freeware icon]


### PR DESCRIPTION
This PR replaces link http://rammichael.com/7-taskbar-tweaker `->` https://tweaker.rammichael.com/

The link comes from [7+ Taskbar Tweaker repo](https://github.com/m417z/7-Taskbar-Tweaker).