### PR TITLE
Update Mailbird link

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,7 +182,7 @@
 
 ### Email
 
-- [Mailbird](https://www.mailbird.com/) - IMAP and POP3 email client, featuring customization, complete touch support and multiple language support.
+- [Mailbird](https://www.getmailbird.com/) - IMAP and POP3 email client, featuring customization, complete touch support and multiple language support.
 - [Mailspring](https://getmailspring.com/) - A fast and maintained fork of Nylas Mail, built on modern web technologies. [![Open-Source Software][oss icon]](https://github.com/Foundry376/Mailspring) ![Freeware][freeware icon]
 - [Nylas Mail](https://www.nylas.com/download/) - An extensible desktop mail app built on the modern web. [![Open-Source Software][oss icon]](https://github.com/nylas/N1) ![Freeware][freeware icon]
 - [Postbox](https://postbox-inc.com/) - The Power Email App


### PR DESCRIPTION
The original link to Mailbird, www.mailbird.com automatically redirects to www.getmailbird.com, therefore it should be updated to reflect the new domain.