### PR TITLE
Update E-book Section: Remove Bookviser and Add Thorium

### DIFF
--- a/README-cn.md
+++ b/README-cn.md
@@ -167,9 +167,9 @@
 - [WPS Office](https://www.wps.com/office-free)-完美的免费办公软件![Freeware][Freeware Icon]
 
 ### 电子书实用程序
-- [Bookviser](http://apps.microsoft.com/windows/zh-cn/app/bookviser-reader/42d4527a-b1fe-479b-ad04-150303dc056f)-Windows 8设备的出色应用程序，可轻松读取电子书 办法。 ![Freeware][Freeware Icon]
 - [Calibre](http://calibre-ebook.com/)-用于电子书管理和转换的强大软件。 [![Open-Source Software][OSS Icon]](http://calibre-ebook.com/get-involved)![Freeware][Freeware Icon]
 - [kobo](https://www.kobo.com/desktop)-用于电子书管理和转换的极其丑陋但功能强大的软件。 ![Freeware][Freeware Icon]
+- [Thorium](https://www.edrlab.org/software/thorium-reader/) - Thorium Reader是一个适用于Win10，Win11，MacOS和Linux的EPUB阅读器 [![Open-Source Software][oss icon]](https://github.com/edrlab/thorium-reader) ![Freeware][freeware icon]
 
 ### 电子邮件
 

--- a/README.md
+++ b/README.md
@@ -176,9 +176,9 @@
 
 ### E-Book Utilities
 
-- [Bookviser](http://apps.microsoft.com/windows/en-us/app/bookviser-reader/42d4527a-b1fe-479b-ad04-150303dc056f) - Awesome application for Windows 8 devices to read eBooks in a simple way. ![Freeware][freeware icon]
 - [Calibre](http://calibre-ebook.com/) - Powerful software for e-book management and conversion. [![Open-Source Software][oss icon]](http://calibre-ebook.com/get-involved) ![Freeware][freeware icon]
 - [kobo](https://www.kobo.com/desktop) - Incredibly ugly but powerful software for ebook management and conversion. ![Freeware][freeware icon]
+- [Thorium](https://www.edrlab.org/software/thorium-reader/) - Thorium Reader is the EPUB reader of choice for Windows 10 and 11, MacOS and Linux. [![Open-Source Software][oss icon]](https://github.com/edrlab/thorium-reader) ![Freeware][freeware icon]
 
 ### Email
 


### PR DESCRIPTION
This pull request updates the E-book section by removing Bookviser and adding Thorium. I've also updated the README-cn.m to reflect this change.

Bookviser's official website is currently returning a 404 error, and the Microsoft app store redirects to the homepage, so I removed it from the E-book section. Thorium is a similar e-book open source reader that I believe will be a good replacement.

![image](https://user-images.githubusercontent.com/69573161/233131080-51e7740c-3dc9-4d22-b81a-cea962121fed.png)
